### PR TITLE
Update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,14 @@ First, make sure you have done a few precautionary steps:
 Second, follow these steps to setup your access token:
 
  1. Add a Pushbullet account in pidgin with your Pushbullet email address (leave the password option blank)
- 2. A prompt window will pop-up with "Approve or Deny" access in Pushbullet. Click "Approve".
- 1. A new page will open with the "Success Token" in it. (In Google Chrome) While on the "Success Token" page do the following:
-    1. Open the Settings (three buttons to top right) > More tools > Developer tools.
-    2. In the top columns, select "Application"
-    3. On the left hand side, select "Local Storage" > "https://www.Pushbullet.com/"
-    4. In the "Key" column select "Desktop", to the right in the "Value" Pushbullet access token is " "
-    5. Copy this code without the ' ' marks
- 4. In Pidgin, Accounts > Manage Accounts > Modify the Pushbullet account
- 5. Paste the correct access code, obtained via the steps above, into the password section
+ 2. Enable the account in Pidgin
+ 3. A prompt window will pop-up with "Approve or Deny" access in Pushbullet. Click "Approve".
+ 4. A new page will open (In Google Chrome) with the "Success Token" in the URL bar. While on the "Success Token" page do the following:
+    a. Open the Chrome browswer Settings (three buttons to top right) > More tools > Developer tools.
+    b. In the top columns, select "Application"
+    c. On the left hand side, select "Local Storage" > "https://www.Pushbullet.com/"
+    d. In the "Key" column select "Desktop", to the right in the "Value" Pushbullet access token is ' '
+    e. Copy this code without the ' ' marks
+ 5. Cancel the "Copy the Success Token URL" Pidgin dialog
+ 6. In Pidgin, Accounts > Manage Accounts > Modify the Pushbullet account
+ 7. Paste the correct access code, obtained via the steps above, into the password section


### PR DESCRIPTION
These are the steps I had to do to get in.

Step #5 was questionable but necessary to continue on with the instructions as they were written.  Maybe all of step #4 can actually be eliminated in favour of pasting the success URL in the dialog in step #5?